### PR TITLE
Tell gcc not to omit frame pointer

### DIFF
--- a/libeppic/Makefile
+++ b/libeppic/Makefile
@@ -24,7 +24,7 @@ LDIRT    = lex.eppic.c lex.eppicpp.c eppic.tab.c eppic.tab.h eppicpp.tab.c \
 LIBDIR	 = /usr/lib
 TARGETS  = libeppic.a
 
-CFLAGS += -g -fPIC
+CFLAGS += -g -fno-omit-frame-pointer -fPIC
 ifeq ($(TARGET), PPC64)
 	CFLAGS += -m64
 endif


### PR DESCRIPTION
After commit 0209874, it's now possible to enable optimization above O0.
But eppic might call __builtin_return_address(1). With O1,
-fomit-frame-pointer is enabled gcc may omit frame pointer.
__builtin_return_address(1) relies on callee preserves RBP as the stack
base, which is untrue if optimization is usded. In this case it may return
wrong value or crash.

In case of any potential failure, use -fno-omit-frame-pointer globally.

Signed-off-by: Kairui Song <ryncsn@gmail.com>