### PR TITLE
Remove duplicated variable declaration

### DIFF
--- a/libeppic/eppic.h
+++ b/libeppic/eppic.h
@@ -471,7 +471,7 @@ type_t  *eppic_addstorage(type_t *t1, type_t *t2);
 type_t  *eppic_getvoidstruct(int ctype);
 
 extern int lineno, needvar, instruct, nomacs, eppic_legacy;
-node_t *lastv;
+extern node_t *lastv;
 
 #define NULLNODE ((node_t*)0)
 


### PR DESCRIPTION
When building on Fedora 32, following error is observed:

...
/usr/bin/ld: ../eppic/libeppic/libeppic.a(eppic_stat.o):/builddir/build/BUILD/kexec-tools-2.0.20/eppic/libeppic/eppic.h:474: multiple definition of `lastv';
../eppic/libeppic/libeppic.a(eppic_func.o):/builddir/build/BUILD/kexec-tools-2.0.20/eppic/libeppic/eppic.h:474: first defined here
...

And apparently, the variable is wrongly declared multiple times. So
remove duplicated declaration.

Signed-off-by: Kairui Song <kasong@redhat.com>