### PR TITLE
The patch removes usage of 'l' option from binutils

### DIFF
--- a/libeppic/Makefile
+++ b/libeppic/Makefile
@@ -104,7 +104,7 @@ default: $(TARGETS)
 $(CFILES): $(HFILES) eppic.tab.h
 
 $(TARGETS): $(OFILES)
-	$(AR) ccurl $(TARGETS) $(OFILES)
+	$(AR) cur $(TARGETS) $(OFILES)
 
 clean: 
 	-/bin/rm -f *.o $(TARGETS) $(LDIRT)


### PR DESCRIPTION
Start with binutils 2.36 the options is used and
has a meaning that breaks a build.