### PR TITLE
Fix name length condition in eppic_getnxtfct()

### DIFF
--- a/libeppic/eppic_func.c
+++ b/libeppic/eppic_func.c
@@ -776,7 +776,7 @@ eppic_getnxtfct(void)
 
             int l=strlen(nxtfunc->name);
 
-            if(MAX_SYMNAMELEN-5 > l > 5 ) {
+            if(MAX_SYMNAMELEN-5 > l && l > 5 ) {
 
                 if(!strcmp(nxtfunc->name+l-5, "_help")) {
 


### PR DESCRIPTION
Comparisons like 'A > B > C' do not have their mathematical meaning. Instead, 'MAX_SYMNAMELEN-5 > l' evaluates to 0 or 1, which is never greater than 5, and the condition is always false.