### PR TITLE
Use make variable INCDIR to find crash include files

### DIFF
--- a/applications/crash/eppic.mk
+++ b/applications/crash/eppic.mk
@@ -9,6 +9,8 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 
+INCDIR=..
+
 ifeq ($(TARGET), PPC64)
         TARGET_FLAGS = -D$(TARGET) -m64
 else
@@ -26,8 +28,8 @@ all:
 lib-eppic: 
 	cd libeppic && make
         
-eppic.so: ../defs.h eppic.c lib-eppic
-	gcc -g -Ilibeppic -I.. -nostartfiles -shared -rdynamic -o eppic.so eppic.c -fPIC $(TARGET_FLAGS) $(GDB_FLAGS) -Llibeppic -leppic 
+eppic.so: $(INCDIR)/defs.h eppic.c lib-eppic
+	gcc -g -Ilibeppic -I$(INCDIR) -nostartfiles -shared -rdynamic -o eppic.so eppic.c -fPIC $(TARGET_FLAGS) $(GDB_FLAGS) -Llibeppic -leppic 
 
 clean:
 	cd libeppic && make clean


### PR DESCRIPTION
This makes no difference when built from within the crash source tree, but it allows to override the directory from the make command line when building the extension separately.