### PR TITLE
Type cleanup

### DIFF
--- a/applications/crash/eppic.c
+++ b/applications/crash/eppic.c
@@ -303,12 +303,6 @@ apimember(char *sname, char *mname, void **stmp)
     return 0;
 }
 
-static char *
-apigetrtype(char *tstr, TYPE_S *t)
-{
-	return 0;
-}
-
 /* test a string for being a hex number */
 static int
 is_hex(char *c)
@@ -614,7 +608,6 @@ apiops icops= {
 	apiputmem, 
 	apimember, 
 	apigetctype, 
-	apigetrtype, 
 	apigetval, 
 	apigetenum, 
 	apigetdefs,

--- a/libeppic/eppic.h
+++ b/libeppic/eppic.h
@@ -354,7 +354,6 @@ void  eppic_freeidx(idx_t *idx);
 void  eppic_freedvar(dvar_t*dv);
 void  eppic_caller(void *p, void *retaddr);
 void  eppic_pushenums(enum_t *et);
-void  eppic_addfunc_ctype(int idx);
 void  eppic_setapiglobs(void);
 void  eppic_setbuiltins(void);
 void  eppic_setdefbtype(int size, int sign);

--- a/libeppic/eppic.h
+++ b/libeppic/eppic.h
@@ -448,7 +448,6 @@ int   eppic_isneg(char *name);
 int   eppicpperror(char *s);
 
 char  *eppic_vartofunc(node_t *name);
-char  *eppic_gettdefname(ull idx);
 char  *eppic_ctypename(int type_t);
 char  *eppic_filempath(char *fname);
 char  *eppic_fileipath(char *fname);

--- a/libeppic/eppic.h
+++ b/libeppic/eppic.h
@@ -218,7 +218,6 @@ typedef DVAR_S {
 
 typedef STINFO_S {
     char        *name;  /* structure name */
-    ull      idx;   /* key for search */
     int      all;   /* local : partial or complete declaration ? */
     TYPE_S       ctype; /* associated type */
     TYPE_S       rtype; /* real type_t when typedef */

--- a/libeppic/eppic.h
+++ b/libeppic/eppic.h
@@ -45,7 +45,6 @@ typedef MEMBER_S {
     int size;   /* size in bytes of the member or of the bit array */
     int fbit;   /* fist bit (-1) is not a bit field */
     int nbits;  /* number of bits for this member */
-    int value;      /* for a enum member, the corresponding value_t */
 
 } member_t;
 

--- a/libeppic/eppic_api.c
+++ b/libeppic/eppic_api.c
@@ -582,6 +582,7 @@ stinfo_t*sti;
         sti=eppic_alloc(sizeof(stinfo_t));
         sti->name=0;
         sti->idx=(ull)sti;
+	sti->ctype.type=ctype;
         eppic_addst(sti);
     }
     return sti;
@@ -724,7 +725,7 @@ char *name=n?NODE_NAME(n):0;
 
     t=eppic_newbtype(0);
     sti=eppic_chkctype(ctype, name);
-    t->type=sti->ctype.type=ctype;
+    t->type=sti->ctype.type;
     t->idx=sti->ctype.idx=sti->idx;
     sti->stm=0;
     mpp=&sti->stm;

--- a/libeppic/eppic_api.c
+++ b/libeppic/eppic_api.c
@@ -962,7 +962,6 @@ static int apiputmem(ull iaddr, void *p, int nbytes) { return 1; }
 static int apimember(char *sname, char *mname, void **stmp) { return 0; }
 static int apigetctype(int ctype, char *name, type_t*tout) { return 0; }
 static char * apigetrtype(char *name, type_t*t) { return ""; }
-static int apialignment(ull idx) { return 0; }
 static int apigetval(char *name, ull *val, value_t *v) { return 0; }
 static int apigetenum(char *name, enum_t *enums) { return 0; }
 static def_t *apigetdefs(void) { return 0; }

--- a/libeppic/eppic_api.c
+++ b/libeppic/eppic_api.c
@@ -956,7 +956,6 @@ static int apigetmem(ull iaddr, void *p, int nbytes) { return 1; }
 static int apiputmem(ull iaddr, void *p, int nbytes) { return 1; }
 static int apimember(char *sname, char *mname, void **stmp) { return 0; }
 static int apigetctype(int ctype, char *name, type_t*tout) { return 0; }
-static char * apigetrtype(char *name, type_t*t) { return ""; }
 static int apigetval(char *name, ull *val, value_t *v) { return 0; }
 static int apigetenum(char *name, enum_t *enums) { return 0; }
 static def_t *apigetdefs(void) { return 0; }
@@ -967,7 +966,6 @@ static apiops nullops= {
         apiputmem, 
         apimember, 
         apigetctype, 
-        apigetrtype, 
         apigetval, 
         apigetenum, 
         apigetdefs, 

--- a/libeppic/eppic_api.c
+++ b/libeppic/eppic_api.c
@@ -60,7 +60,7 @@ stinfo_t*last=&slist;
 
         stinfo_t*next=st->next;
 
-        if(st->ctype.type==V_TYPEDEF && st->idx & LOCALTYPESBASE) {
+        if(st->ctype.type==V_TYPEDEF && st->ctype.idx & LOCALTYPESBASE) {
 
             eppic_free(st->name);
             eppic_free(st);
@@ -133,7 +133,7 @@ stinfo_t*tst;
 
     for(tst=slist.next; tst; tst=tst->next) {
 
-        if(tst->ctype.type == type && tst->idx == idx) {
+        if(tst->ctype.type == type && tst->ctype.idx == idx) {
 
             return tst; 
         }
@@ -255,7 +255,7 @@ problem for the user put this is not a full blown C compiler.
         eppic_pushref(&st->rtype, dv->ref);
         st->name=dv->name;
         dv->name=0;
-        st->idx=eppic_nextidx();
+        st->ctype.idx=eppic_nextidx();
         st->ctype.type=V_TYPEDEF;
 
         eppic_addst(st);
@@ -414,7 +414,7 @@ type_t *t=eppic_newtype();
         st->name=eppic_alloc(strlen(name)+1);
         strcpy(st->name, name);
         st->stm=0;
-        st->idx=st->ctype.idx=(ull)(unsigned long)st;
+        st->ctype.idx=(ull)(unsigned long)st;
         eppic_addst(st);
         if(ctype == V_ENUM) {
             API_GETENUM(name, st->enums);
@@ -581,7 +581,7 @@ stinfo_t*sti;
 
         sti=eppic_alloc(sizeof(stinfo_t));
         sti->name=0;
-        sti->idx=(ull)sti;
+	sti->ctype.idx=(ull)(unsigned long)sti;
 	sti->ctype.type=ctype;
         eppic_addst(sti);
     }
@@ -686,7 +686,7 @@ type_t *t;
     /* we return a simple basetype_t*/
     /* after stahing the idx in rtype */
     t=eppic_newbtype(INT);
-    t->rtype=sti->idx;
+    t->rtype=sti->ctype.idx;
     t->typattr |= eppic_isenum(-1);
         
     return t;
@@ -726,7 +726,7 @@ char *name=n?NODE_NAME(n):0;
     t=eppic_newbtype(0);
     sti=eppic_chkctype(ctype, name);
     t->type=sti->ctype.type;
-    t->idx=sti->ctype.idx=sti->idx;
+    t->idx=sti->ctype.idx;
     sti->stm=0;
     mpp=&sti->stm;
 

--- a/libeppic/eppic_api.c
+++ b/libeppic/eppic_api.c
@@ -910,7 +910,6 @@ printf("Final size = %d\n", t->size);
 #endif
 
     sti->all=1;
-    eppic_addfunc_ctype(sti->idx);
     return t;
 }
 

--- a/libeppic/eppic_api.c
+++ b/libeppic/eppic_api.c
@@ -639,7 +639,7 @@ enum_t *ep=0;
 char *name=n?NODE_NAME(n):0;
 type_t *t;
 
-    if(n) eppic_startctype(ctype, n);
+    if(name) eppic_startctype_named(ctype, name);
     sti=eppic_chkctype(ctype, name);
 
     while(dv) {

--- a/libeppic/eppic_api.c
+++ b/libeppic/eppic_api.c
@@ -279,12 +279,6 @@ stinfo_t *st=(stinfo_t*)(t->idx);
     return !st->all;
 }
 
-char *
-eppic_gettdefname(ull idx)
-{
-    return ((stinfo_t*)(idx))->name;
-}
-
 static int init=0;
 static void
 eppic_chkinit(void)

--- a/libeppic/eppic_api.h
+++ b/libeppic/eppic_api.h
@@ -84,7 +84,6 @@ typedef struct {
     int         (*putmem)(ull, void *, int);        /* read from system image */
     int         (*member)(char *, char *, void **); /* Get a members of a struct/union */
     int         (*getctype)(int ctype, char *, TYPE_S*); /* get struct/union type information */
-    char*       (*getrtype)(char*, TYPE_S *);       /* get complex type information */
     int         (*getval)(char *, ull *addr, VALUE_S *);/* get the value of a system variable */
     int         (*getenum)(char *name, ENUM_S *);   /* get the list of values for an enum type */
     DEF_S*      (*getdefs)(void);                   /* get the list of compiler pre-defined macros */
@@ -129,7 +128,6 @@ extern apiops *eppic_ops;
 #define API_PUTMEM(i, p, n) ((eppic_ops->putmem)((i), (p), (n)))
 #define API_MEMBER(n, mn, s)((eppic_ops->member)((n), (mn), (s)))
 #define API_GETCTYPE(i, n, t)   ((eppic_ops->getctype)((i), (n), (t)))
-#define API_GETRTYPE(i, t)  ((eppic_ops->getrtype)((i), (t)))
 #define API_ALIGNMENT(i)    ((eppic_ops->alignment)((i)))
 #define API_GETVAL(n,a, val)   ((eppic_ops->getval)((n), (a), (val)))
 #define API_GETENUM(n, e)      ((eppic_ops->getenum)(n, e))

--- a/libeppic/eppic_func.c
+++ b/libeppic/eppic_func.c
@@ -29,12 +29,6 @@
 */
 struct fdata;
 
-typedef struct fctype_t {
-    int idx;
-    struct fctype_t*next;
-
-} fctype_t;
-
 typedef struct func {
 
     char *name;     /* name of the function */
@@ -58,7 +52,6 @@ typedef struct fdata {
     var_t*fgvs;     /* associated list of global variables */
     void *globs;        /* handle for these globals */
     func *funcs;        /* chained list of functions */
-    fctype_t *ctypes;   /* ctypes declared by this function */
     struct fdata *next;     /* chained list of files */
 
 } fdata;
@@ -272,7 +265,6 @@ eppic_freefile(fdata *fd)
     if(fd) {
 
         func *fct, *nxt;
-        fctype_t *ct, *nct;
 
         if(fd->isdso) {
 
@@ -299,11 +291,6 @@ eppic_freefile(fdata *fd)
             eppic_freefunc(fct);
         }
 
-        for(ct=fd->ctypes; ct; ct=nct) {
-
-            nct=ct->next;
-            eppic_free(ct);
-        }
         eppic_free(fd->fname);
         if(fd->globs) eppic_rm_globals(fd->globs);
         eppic_free(fd);
@@ -538,16 +525,6 @@ void *h;
     else if(!silent) eppic_msg(dlerror());
     eppic_free(fname);
     return 0;
-}
-
-void
-eppic_addfunc_ctype(int idx)
-{
-fctype_t *fct=eppic_alloc(sizeof(fctype_t));
-
-    fct->idx=idx;
-    fct->next=fall->ctypes;
-    fall->ctypes=fct;
 }
 
 int 

--- a/libeppic/mkbaseop.c
+++ b/libeppic/mkbaseop.c
@@ -133,20 +133,20 @@ int i,j,k;
     printf("void (*opfuncs[%u][%u][%u])()={\n", NTYPS, NTYPS, NOPS);
 
     for(i=0;i<NTYPS;i++) {
-    
+
+        printf("  {\n");
         for(j=0; j<NTYPS;j++) {
 
-            printf("\t");
-
+            printf("    {");
             for(k=0;k<NOPS;k++) {
-
-                if(!k%6) printf("\n\t");
-                printf("op_%s_%s_%s, ", opstbl[k].acro, typtbl[i], typtbl[j]);
-
+                printf("%sop_%s_%s_%s,",
+                       k%4==0 ? "\n      " : " ",
+                       opstbl[k].acro, typtbl[i], typtbl[j]);
             }
-            printf("\n");
+            printf("\n    },\n");
 
         }
+	printf("  },\n");
 
     }
     printf("};\n");


### PR DESCRIPTION
I have spent some time trying to understand the internal representation of eppic code. As a side effect, I have found some dead code which can be removed.