### PR TITLE
Fix build with glibc-2.42

### DIFF
--- a/libeppic/eppic_builtin.c
+++ b/libeppic/eppic_builtin.c
@@ -13,10 +13,11 @@
  * GNU General Public License for more details.
  */
 #include <string.h>
-#include <termio.h>
+#include <termios.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdarg.h>
+#include <sys/ioctl.h>
 #include "eppic.h"
 
 /* information necessary for a builtin function */
@@ -166,7 +167,7 @@ value_t *
 eppic_getchar(void)
 {
 char c; 
-struct termio tio, stio;
+struct termios tio, stio;
 int in=fileno(stdin);
 
     if(ioctl(in, TCGETA, &tio)) c=255;

--- a/libeppic/eppic_util.c
+++ b/libeppic/eppic_util.c
@@ -17,11 +17,12 @@
 #include <unistd.h>
 #include <curses.h>
 #include <term.h>
-#include <termio.h>
+#include <termios.h>
 #include <ctype.h>
 #include <stdarg.h>
 #include <malloc.h>
 #include <limits.h>
+#include <sys/ioctl.h>
 #include <sys/mman.h>
 #include <sys/types.h>
 #include <stdlib.h>


### PR DESCRIPTION
The <termio.h> header and struct termio have long been deprecated, and the next version of glibc will drop them entirely.

https://sourceware.org/git/?p=glibc.git;a=commit;h=e04afb71771710cdc6025fe95908f5f17de7b72d

Signed-off-by: Yaakov Selkowitz <yselkowi@redhat.com>
