### PR TITLE
Use termios instead of termio

### DIFF
--- a/libeppic/eppic_builtin.c
+++ b/libeppic/eppic_builtin.c
@@ -13,7 +13,7 @@
  * GNU General Public License for more details.
  */
 #include <string.h>
-#include <termio.h>
+#include <termios.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdarg.h>
@@ -166,19 +166,19 @@ value_t *
 eppic_getchar(void)
 {
 char c; 
-struct termio tio, stio;
+struct termios tio, stio;
 int in=fileno(stdin);
 
-    if(ioctl(in, TCGETA, &tio)) c=255;
+    if(tcgetattr(in, &tio)) c=255;
     else {
         stio=tio;
         tio.c_lflag &= ~(ICANON | ECHO);
         tio.c_iflag &= ~(ICRNL  | INLCR);
         tio.c_cc[VMIN] = 1;
         tio.c_cc[VTIME] = 0;
-        ioctl(in, TCSETA, &tio);
+        tcsetattr(in, TCSANOW, &tio);
         c=getc(stdin);
-        ioctl(in, TCSETA, &stio);
+        tcsetattr(in, TCSANOW, &stio);
     }
     return eppic_defbtype(eppic_newval(), (ull)c);
 }

--- a/libeppic/eppic_builtin.c
+++ b/libeppic/eppic_builtin.c
@@ -13,11 +13,10 @@
  * GNU General Public License for more details.
  */
 #include <string.h>
-#include <termios.h>
+#include <termio.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdarg.h>
-#include <sys/ioctl.h>
 #include "eppic.h"
 
 /* information necessary for a builtin function */
@@ -167,7 +166,7 @@ value_t *
 eppic_getchar(void)
 {
 char c; 
-struct termios tio, stio;
+struct termio tio, stio;
 int in=fileno(stdin);
 
     if(ioctl(in, TCGETA, &tio)) c=255;

--- a/libeppic/eppic_util.c
+++ b/libeppic/eppic_util.c
@@ -17,12 +17,11 @@
 #include <unistd.h>
 #include <curses.h>
 #include <term.h>
-#include <termios.h>
+#include <termio.h>
 #include <ctype.h>
 #include <stdarg.h>
 #include <malloc.h>
 #include <limits.h>
-#include <sys/ioctl.h>
 #include <sys/mman.h>
 #include <sys/types.h>
 #include <stdlib.h>

--- a/libeppic/eppic_util.c
+++ b/libeppic/eppic_util.c
@@ -17,7 +17,7 @@
 #include <unistd.h>
 #include <curses.h>
 #include <term.h>
-#include <termio.h>
+#include <sys/ioctl.h>
 #include <ctype.h>
 #include <stdarg.h>
 #include <malloc.h>


### PR DESCRIPTION

termio has been obsolete for decades and is no longer supported by glibc.