### PR TITLE
Fix eppic pointer arithmetic bugs

### DIFF
--- a/libeppic/eppic_op.c
+++ b/libeppic/eppic_op.c
@@ -560,6 +560,7 @@ inval:
                 V1;
                 eppic_transfer(v=eppic_newval(), v1,
                           unival(v1) + L2 * size);
+                v->mem += L2 * size;
             }
             break;
             case SUB: { /* expr - expr */
@@ -572,6 +573,7 @@ inval:
                     V1;
                     eppic_transfer(v=eppic_newval(), v1,
                               unival(v1) - L2 * size);
+                    v->mem -= L2 * size;
                 }
             }
             break;
@@ -579,6 +581,7 @@ inval:
                 V1;
                 eppic_transfer(v=eppic_newval(), v1,
                           unival(v1) - size);
+                v->mem -= size;
                 eppic_setval(v1, v);
             }
             break;
@@ -586,6 +589,7 @@ inval:
                 V1;
                 eppic_transfer(v=eppic_newval(), v1,
                           unival(v1) + size);
+                v->mem += size;
                 eppic_setval(v1, v);
             }
             break;
@@ -593,6 +597,7 @@ inval:
                 V1;
                 eppic_transfer(v=eppic_newval(), v1,
                           unival(v1) + size);
+                v->mem += size;
                 eppic_setval(v1, v);
                 eppic_transfer(v, v1, unival(v1));
             }
@@ -601,6 +606,7 @@ inval:
                 V1;
                 eppic_transfer(v=eppic_newval(), v1,
                           unival(v1) - size);
+                v->mem -= size;
                 eppic_setval(v1, v);
                 eppic_transfer(v, v1, unival(v1));
             }


### PR DESCRIPTION
There are pointer arithmetic bugs observed in crash eppic extension, such as *(pointer++) or *(pointer + x), the dereferenced value is incorrect, e.g. the following eppic script:

    char *p = (char *)&linux_banner;
    printf("%s %lx\n", getstr(p), (unsigned long)p);
    printf("%c %lx\n", *(p++), (unsigned long)p);
    printf("%c %lx\n", *(++p), (unsigned long)p);
    printf("%c %lx\n", *(p++), (unsigned long)p);
    printf("%c %lx\n", *(++p), (unsigned long)p);

Output before apply the patch:

    Linux version 6.16.3 ... ffffffff938445f0
    L ffffffff938445f1
    L ffffffff938445f2
    L ffffffff938445f3
    L ffffffff938445f4

Output after apply the patch:

    Linux version 6.16.3 ... ffffffff938445f0
    L ffffffff938445f1
    n ffffffff938445f2
    n ffffffff938445f3
    x ffffffff938445f4

The root cause is for eppic_transfer(), it only set v1->v fields, it doesn't set v1->mem, so arithmetics as pointer++ will always referceing the none-updated mem, that's why 'L' outputted even after pointer changes.