### PR TITLE
Fix the issue of cross-compilation errors

### DIFF
--- a/libeppic/Makefile
+++ b/libeppic/Makefile
@@ -65,14 +65,14 @@ install: headers exports
 	(cd scripts ; $(MAKE) install )
 
 baseops.o: mkbaseop.c
-	$(CC) $(CFLAGS) -o mkbaseop mkbaseop.c
+	gcc $(CFLAGS) -o mkbaseop mkbaseop.c
 	./mkbaseop > baseops.c
-	$(CC) $(CFLAGS) -c baseops.c
+	gcc $(CFLAGS) -c baseops.c
 
 mkbaseop.c eppic_member.o eppic_op.o eppic_stat.o eppic_type.o y.tab.o : eppic.tab.h
 
 lex.eppic.o: lex.eppic.c eppic.tab.c eppic.h
-	$(CC) $(CFLAGS) -c lex.eppic.c
+	gcc $(CFLAGS) -c lex.eppic.c
 
 lex.eppic.c: eppic.l
 	flex -L -Peppic -t eppic.l > lex.eppic.c
@@ -80,16 +80,16 @@ lex.eppic.c: eppic.l
 eppic.tab.c: eppic.tab.h
 
 eppicpp.tab.o: eppicpp.tab.c
-	$(CC) $(CFLAGS) -c eppicpp.tab.c
+	gcc $(CFLAGS) -c eppicpp.tab.c
 
 eppic.tab.o: eppic.tab.c
-	$(CC) $(CFLAGS) -c eppic.tab.c
+	gcc $(CFLAGS) -c eppic.tab.c
 
 eppic.tab.h : eppic.y
 	$(YACC) -peppic -v -t -d eppic.y
 
 lex.eppicpp.o: lex.eppicpp.c eppicpp.tab.c eppic.h
-	$(CC) $(CFLAGS) -c lex.eppicpp.c
+	gcc $(CFLAGS) -c lex.eppicpp.c
 
 lex.eppicpp.c: eppicpp.l
 	flex -Peppicpp -t eppicpp.l  > lex.eppicpp.c
@@ -101,7 +101,9 @@ eppicpp.tab.h : eppicpp.y eppic.tab.h
 
 default: $(TARGETS)
 
-$(CFILES): $(HFILES) eppic.tab.h
+# Explicit compilation rules for C files to use gcc instead of $(CC)
+%.o: %.c $(HFILES) eppic.tab.h
+	gcc $(CFLAGS) -c $< -o $@
 
 $(TARGETS): $(OFILES)
 	$(AR) cur $(TARGETS) $(OFILES)


### PR DESCRIPTION
When performing cross-compilation with "make
CROSS_COMPILE=aarch64-linux-gnu- extensions", the following error will occur:

    aarch64-linux-gnu-gcc -Wall -g -shared -rdynamic -o dminfo.so dminfo.c -fPIC -DARM64  -DGDB_16_2
    aarch64-linux-gnu-gcc -Wall -g -shared -rdynamic -o echo.so echo.c -fPIC -DARM64  -DGDB_16_2
    Cloning into 'eppic'...
    remote: Enumerating objects: 700, done.
    remote: Counting objects: 100% (219/219), done.
    remote: Compressing objects: 100% (90/90), done.
    remote: Total 700 (delta 156), reused 170 (delta 127), pack-reused 481 (from 1)
    Receiving objects: 100% (700/700), 321.84 KiB | 1.24 MiB/s, done.
    Resolving deltas: 100% (378/378), done.
    cd eppic/libeppic && make
    bison -peppic -v -t -d eppic.y
    eppic.y: warning: 135 shift/reduce conflicts [-Wconflicts-sr]
    eppic.y: warning: 22 reduce/reduce conflicts [-Wconflicts-rr]
    eppic.y: note: rerun with option '-Wcounterexamples' to generate conflict counterexamples
    aarch64-linux-gnu-gcc -g -O0 -fno-omit-frame-pointer -fPIC   -c -o eppic_util.o eppic_util.c
    aarch64-linux-gnu-gcc -g -O0 -fno-omit-frame-pointer -fPIC   -c -o eppic_node.o eppic_node.c
    aarch64-linux-gnu-gcc -g -O0 -fno-omit-frame-pointer -fPIC   -c -o eppic_var.o eppic_var.c
    aarch64-linux-gnu-gcc -g -O0 -fno-omit-frame-pointer -fPIC   -c -o eppic_func.o eppic_func.c
    aarch64-linux-gnu-gcc -g -O0 -fno-omit-frame-pointer -fPIC   -c -o eppic_str.o eppic_str.c
    aarch64-linux-gnu-gcc -g -O0 -fno-omit-frame-pointer -fPIC   -c -o eppic_op.o eppic_op.c
    aarch64-linux-gnu-gcc -g -O0 -fno-omit-frame-pointer -fPIC   -c -o eppic_num.o eppic_num.c
    aarch64-linux-gnu-gcc -g -O0 -fno-omit-frame-pointer -fPIC   -c -o eppic_stat.o eppic_stat.c
    aarch64-linux-gnu-gcc -g -O0 -fno-omit-frame-pointer -fPIC   -c -o eppic_builtin.o eppic_builtin.c
    aarch64-linux-gnu-gcc -g -O0 -fno-omit-frame-pointer -fPIC   -c -o eppic_type.o eppic_type.c
    aarch64-linux-gnu-gcc -g -O0 -fno-omit-frame-pointer -fPIC   -c -o eppic_case.o eppic_case.c
    aarch64-linux-gnu-gcc -g -O0 -fno-omit-frame-pointer -fPIC   -c -o eppic_api.o eppic_api.c
    aarch64-linux-gnu-gcc -g -O0 -fno-omit-frame-pointer -fPIC   -c -o eppic_member.o eppic_member.c
    aarch64-linux-gnu-gcc -g -O0 -fno-omit-frame-pointer -fPIC   -c -o eppic_alloc.o eppic_alloc.c
    aarch64-linux-gnu-gcc -g -O0 -fno-omit-frame-pointer -fPIC   -c -o eppic_define.o eppic_define.c
    aarch64-linux-gnu-gcc -g -O0 -fno-omit-frame-pointer -fPIC   -c -o eppic_input.o eppic_input.c
    aarch64-linux-gnu-gcc -g -O0 -fno-omit-frame-pointer -fPIC   -c -o eppic_print.o eppic_print.c
    bison -peppicpp -v -t -d eppicpp.y
    eppicpp.y: warning: 23 shift/reduce conflicts [-Wconflicts-sr]
    eppicpp.y: note: rerun with option '-Wcounterexamples' to generate conflict counterexamples
    aarch64-linux-gnu-gcc -g -O0 -fno-omit-frame-pointer -fPIC -c eppicpp.tab.c
    aarch64-linux-gnu-gcc -g -O0 -fno-omit-frame-pointer -fPIC -c eppic.tab.c
    flex -L -Peppic -t eppic.l > lex.eppic.c
    aarch64-linux-gnu-gcc -g -O0 -fno-omit-frame-pointer -fPIC -c lex.eppic.c
    flex -Peppicpp -t eppicpp.l  > lex.eppicpp.c
    aarch64-linux-gnu-gcc -g -O0 -fno-omit-frame-pointer -fPIC -c lex.eppicpp.c
    aarch64-linux-gnu-gcc -g -O0 -fno-omit-frame-pointer -fPIC -o mkbaseop mkbaseop.c
    ./mkbaseop > baseops.c
    /bin/sh: 1: ./mkbaseop: Exec format error
    make[5]: [Makefile:71: baseops.o] Error 126 (ignored)
    aarch64-linux-gnu-gcc -g -O0 -fno-omit-frame-pointer -fPIC -c baseops.c
    ar cur libeppic.a eppic_util.o eppic_node.o eppic_var.o eppic_func.o eppic_str.o eppic_op.o eppic_num.o eppic_stat.o eppic_builtin.o eppic_type.o eppic_case.o eppic_api.o eppic_member.o eppic_alloc.o eppic_define.o eppic_input.o eppic_print.o eppicpp.tab.o eppic.tab.o lex.eppic.o lex.eppicpp.o baseops.o
    ar: `u' modifier ignored since `D' is the default (see `U')
    gcc -g -O0 -Ieppic/libeppic -I.. -nostartfiles -shared -rdynamic -o eppic.so eppic/applications/crash/eppic.c -fPIC -DARM64 -DGDB_16_2 -Leppic/libeppic -leppic
    /usr/bin/ld: skipping incompatible eppic/libeppic/libeppic.a when searching for -leppic
    /usr/bin/ld: cannot find -leppic: No such file or directory
    collect2: error: ld returned 1 exit status
    make[4]: [eppic.mk:71: eppic.so] Error 1 (ignored)
    gcc -Wall -g -I. -shared -rdynamic -o snap.so snap.c -fPIC -DARM64  -DGDB_16_2

This is because aarch64-linux-gnu-gcc was passed to the eppic commponent via $(CC). This patch fixes this issue by specifying the compiler as gcc during the cross-compilation process.