### PR TITLE
eppic_getctype: Set st->all for successful type resolvation

### DIFF
--- a/libeppic/eppic_api.c
+++ b/libeppic/eppic_api.c
@@ -415,6 +415,7 @@ type_t *t=eppic_newtype();
         strcpy(st->name, name);
         st->stm=0;
         st->ctype.idx=(ull)(unsigned long)st;
+        st->all=1;
         eppic_addst(st);
         if(ctype == V_ENUM) {
             API_GETENUM(name, st->enums);


### PR DESCRIPTION
Currently the st->all is not set in eppic_getctype(). For any successfully resolved types, eppic_ispartial() will return 1 which leads to "Invalid type specified" information. This patch will fix this by set st->all value after successful type resolving in eppic_getctype().

E.g: for the following eppic program:

int main()
{
	printf("%d\n", sizeof(struct task_struct));
	return 0;
}

Before:
    crash> eppic /tmp/test.c
    File /tmp/test.c, line 3, Error: Invalid type specified

The debug shows the type has been resolved in ctype fields:

(gdb) p *(stinfo_t*)(t->idx)
$3 = {name = 0x2360678 "task_struct", all = 0, ctype = {type = 6, idx = 53556248, size = 13696, typattr = 0, ref = 0, fct = 0,
    idxlst = 0x0, rtype = 0}, rtype = {type = 0, idx = 0, size = 0, typattr = 0, ref = 0, fct = 0, idxlst = 0x0, rtype = 0},
  stm = 0x0, enums = 0x0, next = 0x33e85d8}

After:
    crash> eppic /tmp/test.c
    13696

Please note:
1) this issue only exist for eppic v5.0 branch.
2) In order to make "sizeof(struct xxx)" work properly, the crash patch [1] is needed.

[1]: https://www.mail-archive.com/devel@lists.crash-utility.osci.io/msg01778.html