### PR TITLE
Enable auto-run of 'static main()' as a fallback

### DIFF
--- a/libeppic/eppic_api.h
+++ b/libeppic/eppic_api.h
@@ -16,6 +16,9 @@
 /* minor and major version number 
     4.0 switch to new Eppic name and use of fully typed symbols.
 */
+#ifndef EPPIC_API_H
+#define EPPIC_API_H
+
 #define S_MAJOR 5
 #define S_MINOR 0
 
@@ -298,3 +301,5 @@ void eppic_dbg_named(int class, char *name, int level, char *, ...);
 
 /* parsers debug flags */
 extern int eppicdebug, eppicppdebug;
+
+#endif

--- a/libeppic/eppic_func.c
+++ b/libeppic/eppic_func.c
@@ -626,7 +626,7 @@ void *mtag;
         fd->time=time(0);
 
         /* compilation was ok , check for a __init() function to execute */
-        if((fct=eppic_getfbyname("__init", fd))) {
+        if((fct=eppic_getfbyname("__init", fd)) || (fct=eppic_getfbyname("main", fd))) {
 
             int *exval;
             jmp_buf exitjmp;
@@ -809,13 +809,13 @@ char *filename;
 
         if(!filename) {
 
-            eppic_msg("File not found : %s\n", fname);
-            return;
+		eppic_msg("File not found : %s\n", fname);
+		return;
 
-        }
+	    }
 
         line=1;
-        freeit=1;
+            freeit=1;
 
 
     } else {


### PR DESCRIPTION
If, after the compile of a file, __init() is not found, look for main() and execute that one instead.
Also, moved the handling of 'edit -f file.c' to eppic.c (from a patch to crash itself).